### PR TITLE
Add ollama_cloud provider for free hosted model access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-dspy_ai = "^2.4.13"
-ollama = "^0.2.1"
+dspy_ai = "2.4.13"
+ollama = ">=0.4.0"
 matplotlib = "^3.9.1"
+google-generativeai = "^0.8.6"
 
 [build-system]
 requires = ["poetry-core"]

--- a/structured_rag/mock_gfl/dspy_program.py
+++ b/structured_rag/mock_gfl/dspy_program.py
@@ -23,6 +23,9 @@ class dspy_Program(dspy.Module):
     def configure_llm(self, api_key: Optional[str] = None):
         if self.model_provider == "ollama":
             llm = dspy.OllamaLocal(model=self.model_name, max_tokens=4000, timeout_s=480)
+        elif self.model_provider == "ollama_cloud":
+            llm = dspy.OpenAI(model=self.model_name, api_key=api_key,
+                              api_base="https://ollama.com/v1/", model_type="chat", max_tokens=4000)
         elif self.model_provider == "google":
             llm = dspy.Google(model=self.model_name, api_key=api_key)
         elif self.model_provider == "openai":

--- a/structured_rag/mock_gfl/fstring_program.py
+++ b/structured_rag/mock_gfl/fstring_program.py
@@ -20,6 +20,11 @@ class fstring_Program():
         elif self.model_provider == "openai":
             import openai
             self.model = openai.OpenAI(api_key=api_key)
+        elif self.model_provider == "ollama_cloud":
+            self.ollama_client = ollama.Client(
+                host="https://ollama.com",
+                headers={"Authorization": f"Bearer {api_key}"}
+            )
         elif self.model_provider == "anthropic":
             import anthropic
             self.model = anthropic.Anthropic(api_key=api_key)
@@ -36,6 +41,9 @@ class fstring_Program():
             return response.text
         elif self.model_provider == "ollama":
             response = ollama.chat(model=self.model_name, messages=[{"role": "user", "content": connection_prompt}])
+            return response['message']['content']
+        elif self.model_provider == "ollama_cloud":
+            response = self.ollama_client.chat(model=self.model_name, messages=[{"role": "user", "content": connection_prompt}])
             return response['message']['content']
         elif self.model_provider == "openai":
             response = self.model.chat.completions.create(
@@ -72,6 +80,9 @@ class fstring_Program():
         if self.model_provider == "ollama":
             # ToDo, add structured outputs to Ollama
             response = ollama.chat(model=self.model_name, messages=[{"role": "user", "content": prompt}])
+            return response['message']['content']
+        elif self.model_provider == "ollama_cloud":
+            response = self.ollama_client.chat(model=self.model_name, messages=[{"role": "user", "content": prompt}])
             return response['message']['content']
         elif self.model_provider == "google":
             if self.structured_outputs:


### PR DESCRIPTION
## Summary
- Adds a new `ollama_cloud` model provider that routes requests through Ollama's hosted cloud API (`https://ollama.com`), enabling users to run the full benchmark with free cloud-hosted models (e.g. `gemma3:4b`, `gemma3:12b`) without needing a local Ollama installation or paid API keys from OpenAI/Google/Anthropic
- Updates `fstring_program.py` to create an `ollama.Client` with the cloud host and auth header
- Updates `dspy_program.py` to use `dspy.OpenAI` with Ollama's OpenAI-compatible endpoint for DSPy programs
- Upgrades `ollama` dependency to `>=0.4.0` for `Client` header support

## Motivation
The current `ollama` provider requires a locally running Ollama server, which adds setup friction. The `openai`, `google`, and `anthropic` providers all require paid API keys. This PR adds a free, zero-setup alternative: users sign up for a free Ollama cloud account, get an API key, and can immediately run the full benchmark.

## Usage
```bash
poetry run python run_test.py --model_provider ollama_cloud \
    --model_name gemma3:4b \
    --api_key <ollama_cloud_api_key> \
    --all
```

## Test plan
- [x] Verified `fstring_Program` connection test succeeds with `ollama_cloud`
- [x] Verified `dspy_Program` connection test succeeds with `ollama_cloud`
- [x] Ran all 7 test types with `gemma3:4b` via `ollama_cloud` (112 samples each)
- [x] Results saved correctly and match expected JSON schema