### PR TITLE
Implement CLI argument parsing and fix documented script path

### DIFF
--- a/docs/1_run_test.md
+++ b/docs/1_run_test.md
@@ -2,7 +2,7 @@
 
 To run the tests, create the python environment using `poetry install`.
 
-You can then run the script using `poetry run python tests/run_test.py`.
+You can then run the script using `poetry run python structured_rag/run_test/run_scripts/run_test.py`.
 
 `run_test.py` accepts the following command-line arguments:
 

--- a/structured_rag/run_test/run_scripts/run_test.py
+++ b/structured_rag/run_test/run_scripts/run_test.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 import datetime
@@ -224,5 +225,31 @@ def run_test():
     # Print total number of inferences run
     print(f"{Colors.BOLD}Total number of inferences run: {total_inference_count}{Colors.ENDC}")
 
+ALL_TESTS = [
+    "GenerateAnswer",
+    "RateContext",
+    "AssessAnswerability",
+    "ParaphraseQuestions",
+    "GenerateAnswerWithConfidence",
+    "GenerateAnswersWithConfidence",
+    "RAGAS",
+]
+
 if __name__ == "__main__":
-    run_test()
+    parser = argparse.ArgumentParser(description="Run StructuredRAG benchmark tests.")
+    parser.add_argument("--model_name", type=str, default=MODEL_NAME, help="Name of the model to use.")
+    parser.add_argument("--model_provider", type=str, default=MODEL_PROVIDER, help="Provider: ollama, google, openai, anthropic.")
+    parser.add_argument("--api_key", type=str, default=API_KEY, help="API key (not needed for Ollama).")
+    parser.add_argument("--test", type=str, default=TEST_TYPE, help="Test type to run.")
+    parser.add_argument("--all", action="store_true", help="Run all supported test types.")
+    args = parser.parse_args()
+
+    MODEL_NAME = args.model_name
+    MODEL_PROVIDER = args.model_provider
+    API_KEY = args.api_key
+
+    tests_to_run = ALL_TESTS if args.all else [args.test]
+    for test in tests_to_run:
+        TEST_TYPE = test
+        print(f"\n{'='*60}\nRunning test: {TEST_TYPE}\n{'='*60}")
+        run_test()


### PR DESCRIPTION
## Summary
- Implements the `--model_name`, `--model_provider`, `--api_key`, `--test`, and `--all` CLI flags using `argparse`, matching the interface described in `docs/1_run_test.md`
- Fixes the documented script path from `tests/run_test.py` (does not exist) to the actual location at `structured_rag/run_test/run_scripts/run_test.py`

## Motivation
The documentation in `docs/1_run_test.md` describes a CLI interface with named arguments and an `--all` flag, but `run_test.py` only had hardcoded configuration variables — users had to manually edit the source file to change models or test types. This made reproduction harder than necessary and contradicted the documentation.

This change makes it possible to run the full benchmark from the command line exactly as documented:
```bash
poetry run python structured_rag/run_test/run_scripts/run_test.py \
    --model_provider ollama \
    --model_name llama3 \
    --all
```

## Test plan
- [x] Verified `--model_name`, `--model_provider`, and `--api_key` override defaults
- [x] Verified `--test AssessAnswerability` runs a single test
- [x] Verified `--all` runs all 7 supported test types sequentially
- [x] Verified backward compatibility (running without args uses existing defaults)